### PR TITLE
Use correct type for ConfigureProperty

### DIFF
--- a/src/lib/modules/app/application_context.ts
+++ b/src/lib/modules/app/application_context.ts
@@ -5,7 +5,7 @@ import { Serialize } from "../meta/serialize";
 @Serialize.Manage()
 export class AppContext
 {
-	@Serialize.ConfigureProperty({ })
+	@Serialize.ConfigureProperty( { Ignored: true } )
 	public crumbs : Writable< Array< {text:null|string, href:string, icon:undefined|string, postfix_icon:boolean} > > = writable([]);
 }
 export const app = new AppContext();

--- a/src/lib/modules/meta/serialize.ts
+++ b/src/lib/modules/meta/serialize.ts
@@ -115,14 +115,14 @@ export namespace Serialize // eslint-disable-line @typescript-eslint/no-namespac
 		}
 	}
 	
-	export function ConfigureProperty<T extends object>( options: any )
+	export function ConfigureProperty<T extends object>( options: Partial<PropertySerializationOptions<any>> )
 	{
 		return function( target: T, property_identifier: string|symbol )
 		{
 			const prototype = target as PrototypeOf<T>;
 			const prop_key	= property_identifier as keyof T;
 			const info = Get( prototype );
-			info.Properties[ prop_key ] = Object.assign( info.Properties[ prop_key ] ?? {}, options );
+			info.Properties[ prop_key ] = Object.assign( info.Properties[ prop_key ] ?? {}, options ) as PropertySerializationOptions<any>;
 		}
 	}
 


### PR DESCRIPTION
Close #18: Set the parameter type for the Configure Property decorator correctly. As far as I know, there's no way to get the type of the poperty the decorator is running on, I have to use `any` for the `PropertySerializationOptions` template type.